### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Steven Sheldon", "Raphael Amorim"]
 description = "Objective-C Runtime bindings and wrapper for Rust. Maintained fork of objc crate"
 keywords = ["objective-c", "osx", "ios", "cocoa", "uikit"]
 readme = "README.md"
-repository = "http://github.com/raphamorim/objc-rs"
-documentation = "http://github.com/raphamorim/objc-rs"
+repository = "https://github.com/raphamorim/objc-rs"
+documentation = "https://github.com/raphamorim/objc-rs"
 license = "MIT"
 edition = "2021"
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97